### PR TITLE
Fix crash on unhandled case clause

### DIFF
--- a/src/unite_compact.erl
+++ b/src/unite_compact.erl
@@ -205,7 +205,8 @@ format_info(Failure, {abort, {Reason, {E, R, ST}}}) ->
         [
             color:yellowb(case Reason of
                 setup_failed -> "Setup failed: ";
-                cleanup_failed -> "Cleanup failed: "
+                cleanup_failed -> "Cleanup failed: ";
+                instantiation_failed -> "Instantiation failed: "
             end),
             io_lib:format("~n", []),
             color:yellow(format_exception(E, R, ST))


### PR DESCRIPTION
Without this modification there is a crash and no useful output when handling an 'instantiation_failed' Failure: 

For example:

=ERROR REPORT==== 17-Jul-2017::13:26:51 ===
Error in process <0.290.0> with exit value:
{{case_clause,instantiation_failed},
 [{unite_compact,format_info,2,
                 [{file,"/common/hackney/_build/test/lib/unite/src/unite_compact.erl"},
                  {line,211}]},
  {unite_compact,print_failure,2,
                 [{file,"/common/hackney/_build/test/lib/unite/src/unite_compact.erl"},
                  {line,99}]},
  {unite_compact,'-print_failures/1-lc$^0/1-0-',1,
                 [{file,"/common/hackney/_build/test/lib/unite/src/unite_compact.erl"},
                  {line,90}]},
  {unite_compact,print_failures,1,
                 [{file,"/common/hackney/_build/test/lib/unite/src/unite_compact.erl"},
                  {line,90}]},
  {unite_compact,terminate,2,
                 [{file,"/common/hackney/_build/test/lib/unite/src/unite_compact.erl"},
                  {line,68}]},
  {eunit_listener,call,3,[{file,"eunit_listener.erl"},{line,132}]},
  {eunit_listener,'-init_fun/2-fun-0-',2,
                  [{file,"eunit_listener.erl"},{line,63}]}]}