### PR TITLE
Do not attempt to pretty-print expressions that cannot be parsed

### DIFF
--- a/src/unite_compact.erl
+++ b/src/unite_compact.erl
@@ -307,8 +307,10 @@ format_macro_string(Str) ->
             [C || C <- Str, C =/= $ ];
         false ->
             {ok, S, _} = erl_scan:string(Str ++ "."),
-            {ok, P} = erl_parse:parse_exprs(S),
-            erl_pp:exprs(P)
+            case erl_parse:parse_exprs(S) of
+              {ok, P} -> erl_pp:exprs(P);
+              _ -> Str
+            end
     end.
 
 % Profiling

--- a/test/unite_test.erl
+++ b/test/unite_test.erl
@@ -32,6 +32,12 @@ assert_equal_test() ->
         }
     ).
 
+assert_match_test() ->
+    ?assertMatch(
+       X when X < 1,
+       2
+    ).
+
 error_test() -> error(error_in_test).
 
 exit_test() -> exit(exit_in_test).


### PR DESCRIPTION
Some "expressions" cannot be parsed as expressions (e.g. "X when X < 1"). When parsing fails, just print the string as-is.

Fixes #14