### PR TITLE
Fix `badarg` in format/1

### DIFF
--- a/src/unite_compact.erl
+++ b/src/unite_compact.erl
@@ -504,7 +504,7 @@ format_exception(I, Class, Reason, StackTrace, StackFun, FormatFun) ->
 escape_exception(String) ->
     % If the stack trace contained a call to io:format with a control sequence,
     % we need to escape it since we use io:format ourselves later on:
-    string:replace(String, "~", "~~").
+    string:replace(String, "~", "~~", all).
 
 group_by(Fun, List) ->
     lists:foldl(fun(Item, Acc) ->

--- a/src/unite_compact.erl
+++ b/src/unite_compact.erl
@@ -495,7 +495,7 @@ elapsed_millisecond(Start) ->
     Elapsed = current_time() - Start,
     erlang:convert_time_unit(Elapsed, native, millisecond).
 
-format(Format)       -> format(Format, []).
+format(Format)       -> format("~ts", [Format]).
 format(Format, Data) -> io:format(iolist_to_binary(Format), Data).
 
 format_exception(I, Class, Reason, StackTrace, StackFun, FormatFun) ->


### PR DESCRIPTION
This happens if the `Format` string contains a "~" (tilde). For example if the assertion expression contains a call to `io:format/2`.

The `t` modifier makes it unicode friendly independent of the current VM args.