### PR TITLE
Remove spurious `~n` in failure message

### DIFF
--- a/src/unite_compact.erl
+++ b/src/unite_compact.erl
@@ -108,7 +108,7 @@ terminate({ok, Result}, #s{cases = Cases} = State) ->
 print_failures(#{failed := Failures}) ->
     Indexed = lists:zip(lists:seq(1, length(Failures)), Failures),
     [print_failure(I, F) || {I, F} <- Indexed],
-    format("~n");
+    format("~n", []);
 print_failures(_Cases) ->
     ok.
 


### PR DESCRIPTION
The `~n` is converted to an endline, so now there are two of them after the list of failures.

![screenshot_demo_unite](https://github.com/user-attachments/assets/1950ef7a-47d0-4870-9279-df144fb80277)

Fixes #24.